### PR TITLE
feat: add Import to Letterboxd button in header

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -7,6 +7,8 @@
                 <h1 class="title">Plex2Letterboxd</h1>
             </div>
             <div class="header-right">
+                <IconButton title="Import to Letterboxd" icon="arrow-up-right-from-square" :active=false
+                    :show-animation=false @buttonClick="handleImport"></IconButton>
                 <IconButton title="Start Export" icon="play" :show-animation=isLoading :active=true
                     @buttonClick="handleStart"></IconButton>
                 <IconButton title="Settings" icon="gear" :active=false @buttonClick="handleSetting"
@@ -48,6 +50,10 @@ const handleStart = () => {
         isLoading.value = false
         toast.error("Check your config, something went wrong.")
     })
+}
+
+const handleImport = () => {
+    window.open('https://letterboxd.com/import/', '_blank')
 }
 
 const handleSetting = () => {


### PR DESCRIPTION
## Summary

- Adds an **Import to Letterboxd** button to the left of the existing **Start Export** button in the header
- Clicking it opens `https://letterboxd.com/import/` in a new tab
- Makes the export-then-import workflow seamless — one click after exporting takes the user straight to Letterboxd's import page

## Test plan

- [ ] Click **Import to Letterboxd** — confirm it opens `https://letterboxd.com/import/` in a new tab
- [ ] Confirm **Start Export** still works normally
- [ ] Confirm **Settings** and GitHub link are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)